### PR TITLE
chore(deps): update 10 workflow dependencies

### DIFF
--- a/.github/workflows/build-ci-images.yml
+++ b/.github/workflows/build-ci-images.yml
@@ -19,20 +19,20 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set lowercase owner
         run: echo "OWNER=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .github/images/opensuse-tumbleweed-ci
           push: true
@@ -53,20 +53,20 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set lowercase owner
         run: echo "OWNER=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .github/images/voidlinux-ci
           push: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.22"
           cache: true
@@ -55,16 +55,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.22"
           cache: true
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: latest
           args: --timeout=5m
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: ShellCheck — scripts
         uses: ludeeus/action-shellcheck@master

--- a/.github/workflows/distro-matrix.yml
+++ b/.github/workflows/distro-matrix.yml
@@ -31,20 +31,20 @@ jobs:
           - image: voidlinux-ci
             context: .github/images/voidlinux-ci
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set lowercase owner
         run: echo "OWNER=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: ${{ matrix.context }}
           push: true
@@ -168,10 +168,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.22"
           cache: true


### PR DESCRIPTION
Upstreamed from OpenOS-Project-OSP/penguins-immutable-framework#2.

---

Automated dependency update for GitHub Actions workflow files.

**`.github/workflows/distro-matrix.yml`**
- `actions/checkout@v4` → `actions/checkout@v6` — newer major available (v4 → v6)
- `actions/setup-go@v5` → `actions/setup-go@v6` — newer major available (v5 → v6)
- `docker/build-push-action@v5` → `docker/build-push-action@v7` — newer major available (v5 → v7)
- `docker/login-action@v3` → `docker/login-action@v4` — newer major available (v3 → v4)

**`.github/workflows/build-ci-images.yml`**
- `actions/checkout@v4` → `actions/checkout@v6` — newer major available (v4 → v6)
- `docker/build-push-action@v5` → `docker/build-push-action@v7` — newer major available (v5 → v7)
- `docker/login-action@v3` → `docker/login-action@v4` — newer major available (v3 → v4)

**`.github/workflows/ci.yml`**
- `actions/checkout@v4` → `actions/checkout@v6` — newer major available (v4 → v6)
- `actions/setup-go@v5` → `actions/setup-go@v6` — newer major available (v5 → v6)
- `golangci/golangci-lint-action@v6` → `golangci/golangci-lint-action@v9` — newer major available (v6 → v9)


---
*Generated by [update-infra-deps.yml](/.github/workflows/update-infra-deps.yml) on 2026-05-11.*
*EOL data sourced from [endoflife.date](https://endoflife.date).*